### PR TITLE
add PHP coding standards checks

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,10 +1,10 @@
 name: PHP Coding Standards
 
+# This workflow is triggered whenever commits are pushed to the main branch or manually triggered using the "workflow_dispatch" event
 on:
   push:
     branches:
       - master
-      - 'test-workflow'
   workflow_dispatch:
 
 jobs:
@@ -12,8 +12,10 @@ jobs:
     name: PHP coding standards
     runs-on: ubuntu-latest
     permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
       contents: write
     steps:
+      # Checkout the repository to access its content.
       - uses: actions/checkout@v4.1.0
         name: 'Checkout repository'
 
@@ -21,6 +23,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
+      # Cache Composer dependencies to speed up future runs.
       - uses: actions/cache@v3.3.2
         env:
           cache-name: cache-composer-dependencies
@@ -30,6 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
+      # Set up the PHP environment.
       - name: Setup PHP Action
         uses: shivammathur/setup-php@2.26.0 
         with:
@@ -52,8 +56,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_default_configuration_file: true
-          phpcs_args: '-n' 
+          phpcs_args: '-n' # ignore warnings
 
+      # Automatically commit the fixes made by PHP Code Sniffer.
       - uses: stefanzweifel/git-auto-commit-action@v4 
         with:
           commit_message: Fix PHPCS errors

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,60 @@
+name: PHP Coding Standards
+
+on:
+  push:
+    branches:
+      - master
+      - 'test-workflow'
+  workflow_dispatch:
+
+jobs:
+  phpcs:
+    name: PHP coding standards
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4.1.0
+        name: 'Checkout repository'
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3.3.2
+        env:
+          cache-name: cache-composer-dependencies
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@2.26.0 
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: composer, cs2pr
+
+      - name: Log debug information
+        run: |
+          php --version
+          composer --version
+
+      - name: Install Composer dependencies
+        run: |
+            composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+            echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+
+      - name: Run & fix PHP Code Sniffer
+        uses: shalior/wordpress-phpcs-action@v1.0.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_default_configuration_file: true
+          phpcs_args: '-n' 
+
+      - uses: stefanzweifel/git-auto-commit-action@v4 
+        with:
+          commit_message: Fix PHPCS errors
+

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,11 +1,10 @@
 name: Continuous Deployment Workflow
 
-# This workflow is triggered whenever commits are pushed to the main branch
+# This workflow is triggered whenever commits are pushed to the main branch or manually triggered using the "workflow_dispatch" event.
 on:
   push:
     branches:
       - main
-      - 'test-workflow'
   workflow_dispatch:
 
       
@@ -14,17 +13,17 @@ defaults:
     shell: bash
 
 jobs:
-  # ======================================================
-  # Deploy the main branch to EC2 server
-  # ======================================================
+  # Deploy the main branch to EC2 server.
   deploy_development:
     name: 'Deploy to EC2'
     runs-on: ubuntu-latest
     
     steps:
+      # Checkout the repository to access its content.
       - uses: actions/checkout@v4.1.0
         name: 'Checkout repository'
 
+      # Deploy files to the server using rsync.
       - uses: Burnett01/rsync-deployments@6.0.0
         name: 'Deploy to server'
         with:

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,104 @@
+{
+    "name": "composer/composer",
+    "type": "library",
+    "description": "Composer helps you declare, manage and install dependencies of PHP projects. It ensures you have the right stack everywhere.",
+    "keywords": [
+        "package",
+        "dependency",
+        "autoload"
+    ],
+    "homepage": "https://getcomposer.org/",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nils Adermann",
+            "email": "naderman@naderman.de",
+            "homepage": "https://www.naderman.de"
+        },
+        {
+            "name": "Jordi Boggiano",
+            "email": "j.boggiano@seld.be",
+            "homepage": "https://seld.be"
+        }
+    ],
+    "require": {
+        "php": "^7.2.5 || ^8.0",
+        "composer/ca-bundle": "^1.0",
+        "composer/class-map-generator": "^1.0",
+        "composer/metadata-minifier": "^1.0",
+        "composer/semver": "^3.2.5",
+        "composer/spdx-licenses": "^1.5.7",
+        "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
+        "justinrainbow/json-schema": "^5.2.11",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
+        "seld/jsonlint": "^1.4",
+        "seld/phar-utils": "^1.2",
+        "symfony/console": "^5.4.11 || ^6.0.11 || ^7",
+        "symfony/filesystem": "^5.4 || ^6.0 || ^7",
+        "symfony/finder": "^5.4 || ^6.0 || ^7",
+        "symfony/process": "^5.4 || ^6.0 || ^7",
+        "react/promise": "^2.8 || ^3",
+        "composer/pcre": "^2.1 || ^3.1",
+        "symfony/polyfill-php73": "^1.24",
+        "symfony/polyfill-php80": "^1.24",
+        "symfony/polyfill-php81": "^1.24",
+        "seld/signal-handler": "^2.0"
+    },
+    "require-dev": {
+        "symfony/phpunit-bridge": "^6.0 || ^7",
+        "phpstan/phpstan": "^1.9.3",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1",
+        "phpstan/phpstan-strict-rules": "^1",
+        "phpstan/phpstan-symfony": "^1.2.10"
+    },
+    "suggest": {
+        "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
+        "ext-zip": "Enabling the zip extension allows you to unzip archives",
+        "ext-zlib": "Allow gzip compression of HTTP requests"
+    },
+    "config": {
+        "platform": {
+            "php": "7.2.5"
+        },
+        "platform-check": false
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "2.6-dev"
+        },
+        "phpstan": {
+            "includes": [
+                "phpstan/rules.neon"
+            ]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Composer\\": "src/Composer/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Composer\\Test\\": "tests/Composer/Test/"
+        }
+    },
+    "bin": [
+        "bin/composer"
+    ],
+    "scripts": {
+        "compile": "@php -dphar.readonly=0 bin/compile",
+        "test": "@php simple-phpunit",
+        "phpstan": "@php vendor/bin/phpstan analyse --configuration=phpstan/config.neon"
+    },
+    "scripts-descriptions": {
+        "compile": "Compile composer.phar",
+        "test": "Run all tests",
+        "phpstan": "Runs PHPStan"
+    },
+    "support": {
+        "issues": "https://github.com/composer/composer/issues",
+        "irc": "ircs://irc.libera.chat:6697/composer",
+        "security": "https://github.com/composer/composer/security/policy"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1",
         "phpstan/phpstan-strict-rules": "^1",
-        "phpstan/phpstan-symfony": "^1.2.10"
+        "phpstan/phpstan-symfony": "^1.2.10",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "suggest": {
         "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",


### PR DESCRIPTION
This pull request is all about cleaning up my PHP code and making it look neat and tidy 🧹

Here's the lowdown:
- Whenever I push changes to 'master' or give it a nudge manually, this action kicks in
- It grabs my code and checks it for coding standards
- It uses PHP 8.1 and Composer 
- You'll see PHP and Composer versions in the logs
- It installs Composer dependencies
- Then, it runs PHP Code Sniffer (PHPCS) to check for style issues and fixes them
- Best part? It automatically commits those fixes for me. 🎉